### PR TITLE
Update homepage in netkan

### DIFF
--- a/NetKAN/B9AnimationModules.netkan
+++ b/NetKAN/B9AnimationModules.netkan
@@ -9,7 +9,7 @@
     "license"        : "LGPL-3.0",
     "release_status" : "stable",
     "resources": {
-        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/155491-*"
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?showtopic=155491"
     },
     "install": [
         {

--- a/NetKAN/B9AnimationModules.netkan
+++ b/NetKAN/B9AnimationModules.netkan
@@ -9,7 +9,7 @@
     "license"        : "LGPL-3.0",
     "release_status" : "stable",
     "resources": {
-        "homepage" : "http://forum.kerbalspaceprogram.com/threads/92630"
+        "homepage" : "https://forum.kerbalspaceprogram.com/index.php?/topic/155491-*"
     },
     "install": [
         {


### PR DESCRIPTION
The current homepage link for B9AnimationModules no longer works. This pull request updates it to point to the current B9 Aerospace thread.